### PR TITLE
allow use of uint32 in SOA

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -444,11 +444,11 @@ class Rdata:
             raise ValueError('not a boolean')
 
     @classmethod
-    def _as_ttl(cls, value):
+    def _as_ttl(cls, value, max_value=dns.ttl.MAX_TTL):
         if isinstance(value, int):
-            return cls._as_int(value, 0, dns.ttl.MAX_TTL)
+            return cls._as_int(value, 0, max_value)
         elif isinstance(value, str):
-            return dns.ttl.from_text(value)
+            return dns.ttl.from_text(value, max_value=max_value)
         else:
             raise ValueError('not a TTL')
 

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -57,10 +57,10 @@ class SOA(dns.rdata.Rdata):
         mname = tok.get_name(origin, relativize, relativize_to)
         rname = tok.get_name(origin, relativize, relativize_to)
         serial = tok.get_uint32()
-        refresh = tok.get_uint32()
-        retry = tok.get_uint32()
-        expire = tok.get_uint32()
-        minimum = tok.get_uint32()
+        refresh = tok.get_ttl(max_value=2**32-1)
+        retry = tok.get_ttl(max_value=2**32-1)
+        expire = tok.get_ttl(max_value=2**32-1)
+        minimum = tok.get_ttl(max_value=2**32-1)
         return cls(rdclass, rdtype, mname, rname, serial, refresh, retry,
                    expire, minimum)
 

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -39,10 +39,10 @@ class SOA(dns.rdata.Rdata):
         self.mname = self._as_name(mname)
         self.rname = self._as_name(rname)
         self.serial = self._as_uint32(serial)
-        self.refresh = self._as_ttl(refresh)
-        self.retry = self._as_ttl(retry)
-        self.expire = self._as_ttl(expire)
-        self.minimum = self._as_ttl(minimum)
+        self.refresh = self._as_uint32(refresh)
+        self.retry = self._as_uint32(retry)
+        self.expire = self._as_uint32(expire)
+        self.minimum = self._as_uint32(minimum)
 
     def to_text(self, origin=None, relativize=True, **kw):
         mname = self.mname.choose_relativity(origin, relativize)
@@ -57,10 +57,10 @@ class SOA(dns.rdata.Rdata):
         mname = tok.get_name(origin, relativize, relativize_to)
         rname = tok.get_name(origin, relativize, relativize_to)
         serial = tok.get_uint32()
-        refresh = tok.get_ttl()
-        retry = tok.get_ttl()
-        expire = tok.get_ttl()
-        minimum = tok.get_ttl()
+        refresh = tok.get_uint32()
+        retry = tok.get_uint32()
+        expire = tok.get_uint32()
+        minimum = tok.get_uint32()
         return cls(rdclass, rdtype, mname, rname, serial, refresh, retry,
                    expire, minimum)
 

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -39,10 +39,10 @@ class SOA(dns.rdata.Rdata):
         self.mname = self._as_name(mname)
         self.rname = self._as_name(rname)
         self.serial = self._as_uint32(serial)
-        self.refresh = self._as_uint32(refresh)
-        self.retry = self._as_uint32(retry)
-        self.expire = self._as_uint32(expire)
-        self.minimum = self._as_uint32(minimum)
+        self.refresh = self._as_ttl(refresh, max_value=2**32-1)
+        self.retry = self._as_ttl(retry, max_value=2**32-1)
+        self.expire = self._as_ttl(expire, max_value=2**32-1)
+        self.minimum = self._as_ttl(minimum, max_value=2**32-1)
 
     def to_text(self, origin=None, relativize=True, **kw):
         mname = self.mname.choose_relativity(origin, relativize)

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -660,7 +660,7 @@ class Tokenizer:
     def get_eol(self):
         return self.get_eol_as_token().value
 
-    def get_ttl(self):
+    def get_ttl(self, max_value=dns.ttl.MAX_TTL):
         """Read the next token and interpret it as a DNS TTL.
 
         Raises dns.exception.SyntaxError or dns.ttl.BadTTL if not an
@@ -672,4 +672,4 @@ class Tokenizer:
         token = self.get().unescape()
         if not token.is_identifier():
             raise dns.exception.SyntaxError('expecting an identifier')
-        return dns.ttl.from_text(token.value)
+        return dns.ttl.from_text(token.value, max_value=max_value)

--- a/dns/ttl.py
+++ b/dns/ttl.py
@@ -25,12 +25,13 @@ class BadTTL(dns.exception.SyntaxError):
     """DNS TTL value is not well-formed."""
 
 
-def from_text(text):
+def from_text(text, max_value=MAX_TTL):
     """Convert the text form of a TTL to an integer.
 
     The BIND 8 units syntax for TTLs (e.g. '1w6d4h3m10s') is supported.
 
     *text*, a ``str``, the textual TTL.
+    *max_value*, a ``int`` limiting the maximum value to parse SOA values
 
     Raises ``dns.ttl.BadTTL`` if the TTL is not well-formed.
 
@@ -70,8 +71,8 @@ def from_text(text):
                 need_digit = True
         if not current == 0:
             raise BadTTL("trailing integer")
-    if total < 0 or total > MAX_TTL:
-        raise BadTTL("TTL should be between 0 and 2^31 - 1 (inclusive)")
+    if total < 0 or total > max_value:
+        raise BadTTL("TTL should be between 0 and %d (inclusive)" % max_value)
     return total
 
 


### PR DESCRIPTION
I am currently doing some DNS measurements for a paper and stumbled upon a bunch of queries that failed,
because the answers contained SOA records with values in one of REFRESH, RETRY, EXPIRE or MINIMUM that
are between 2^31-1 and 2^32-1.

If I understand RFC1035 and the clarifications in  RFC 2181, section 8, correctly, only the TTL values of ressource 
records are to be limited to 2^31-1 but REFRESH, RETRY, EXPIRE and MINIMUM in the SOA are still 32 bit unsigned integers. 

Powerdns, knot and the dig utility allow such values and there are nameservers on the Internet serving such SOA records.

Example:
```
$ dig +short SOA 17.87.64.in-addr.arpa.
ns1.americanis.net. support.americanis.net. 2541206765 43200 2251427590 43200 7200
```
with  `2^31-1 <  2251427590 < 2^32-1`



